### PR TITLE
Use recommended method for building gRPC and Protobufs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
  "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -172,11 +172,10 @@ name = "cerberus-proto"
 version = "0.3.0"
 dependencies = [
  "grpc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpc-compiler 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpc-rust 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "protoc-rust 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tls-api 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc-rust-grpc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tls-api 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -303,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "fern"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -354,11 +353,11 @@ dependencies = [
  "httpbis 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tls-api 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tls-api-stub 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tls-api 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tls-api-stub 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tls-api 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tls-api 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -403,7 +402,7 @@ dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fern 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fern 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lapin-futures 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -436,12 +435,12 @@ dependencies = [
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "tls-api 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tls-api-stub 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tls-api 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tls-api-stub 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tls-api 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tls-api 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -769,6 +768,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "protoc-rust-grpc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "grpc-compiler 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc-rust 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1095,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "tls-api"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1103,10 +1114,10 @@ dependencies = [
 
 [[package]]
 name = "tls-api-stub"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "tls-api 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tls-api 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1146,11 +1157,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-tls-api"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "tls-api 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tls-api 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1290,7 +1301,7 @@ dependencies = [
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tls-api 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tls-api 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.1.0",
  "uuid 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1335,7 +1346,7 @@ dependencies = [
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
-"checksum fern 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b7c5e874ad519490806243e9a6dfff638f4822aecb1847390d2e82d4486f73c6"
+"checksum fern 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "50475651fccc56343c766e4d1889428ea753308a977e1315db358ada28cc8c9d"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0bab5b5e94f5c31fc764ba5dd9ad16568aae5d4825538c01d6bca680c9bf94a7"
@@ -1387,6 +1398,7 @@ dependencies = [
 "checksum protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bec26e67194b7d991908145fdf21b7cae8b08423d96dcb9e860cd31f854b9506"
 "checksum protoc 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5379c34ea2f9c69b99e6f25f6d0e6619876195ae7a3dcaf69f66bdb6c2e4dceb"
 "checksum protoc-rust 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e211a7f56b2d020a59d483f652cfdfa6fd42e37bf544c0231e373807aa316c45"
+"checksum protoc-rust-grpc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "68bc8fa6685f274fe41d6d47e3c7d702662ff7c268e5bfa8d5e7a809784418c6"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
@@ -1399,7 +1411,7 @@ dependencies = [
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
 "checksum remove_dir_all 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5d2f806b0fcdabd98acd380dc8daef485e22bcb7cddc811d1337967f2528cf5"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
-"checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
+"checksum rustc-demangle 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f312457f8a4fa31d3581a6f423a70d6c33a10b95291985df55f1ff670ec10ce8"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9743a7670d88d5d52950408ecdb7c71d8986251ab604d4689dd2ca25c9bca69"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
@@ -1428,12 +1440,12 @@ dependencies = [
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
-"checksum tls-api 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "0d20cc40863a888b09ae65aa8d95ad33e31a73bffc482d3958a53a4b4bb33873"
-"checksum tls-api-stub 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f70bbfc47155d106a67046be5a71a459ff1262936439cc6f6e0d9dfbec28c7"
+"checksum tls-api 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "a2424af93d25301cead84cc8225f119918e63d44ee494a0209338dcf7d1eec18"
+"checksum tls-api-stub 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "f8cf9d37d193ad3e78efb7c85b6c00311d90ed32755a16c62080d1711c1d99fb"
 "checksum tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "52b4e32d8edbf29501aabb3570f027c6ceb00ccef6538f4bddba0200503e74e8"
 "checksum tokio-io 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b9532748772222bf70297ec0e2ad0f17213b4a7dd0e6afb68e0a0768f69f4e4f"
 "checksum tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6131e780037787ff1b3f8aad9da83bca02438b72277850dd6ad0d455e0e20efc"
-"checksum tokio-tls-api 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "facd5a944b2fd710d2f4899a923b9da52a7db097df995f55091539021b34983b"
+"checksum tokio-tls-api 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "a47b126d55dc5f9407eeba619a305ca70a8ba8f7d6b813bfaf93e924afe27ce1"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -10,6 +10,4 @@ grpc-rust = "0.1.0"
 tls-api = "0.1.10"
 
 [build-dependencies]
-protobuf = "1.4.1"
-protoc-rust = "1.4.1"
-grpc-compiler = "0.2.1"
+protoc-rust-grpc = "0.2.1"

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,55 +1,10 @@
-extern crate grpc_compiler;
-extern crate protobuf;
-
-use std::fs::File;
-use std::io::Write;
-use std::path::Path;
-use std::path::PathBuf;
-use std::process::Command;
-
-use grpc_compiler::codegen as grpc_gen;
-use protobuf::codegen as pb_gen;
-use protobuf::compiler_plugin::GenResult;
-use protobuf::descriptor::FileDescriptorSet;
-
-fn write_output_files(output_path: PathBuf, results: Vec<GenResult>) {
-    for res in results {
-        let out_file_path: PathBuf = output_path.join(&res.name);
-        let mut out_file = File::create(&out_file_path).unwrap();
-        out_file.write_all(&res.content).unwrap();
-    }
-}
-
-fn compile(proto_name: &str) {
-    let output_path = Path::new("src");
-    let proto_desc_path = output_path.join(&format!("{}.desc", proto_name));
-
-    let mut protoc = Command::new("protoc");
-    protoc.args(&["-o", &format!("{}", proto_desc_path.display())]);
-    protoc.arg(format!("{}.proto", proto_name));
-    let status = protoc.status().unwrap();
-    if !status.success() {
-        panic!("failed to run {:?}: {}", protoc, status);
-    }
-
-    let mut proto_desc_file = File::open(proto_desc_path).unwrap();
-    let proto_desc: FileDescriptorSet = protobuf::parse_from_reader(&mut proto_desc_file).unwrap();
-
-    let proto_results: Vec<GenResult> = pb_gen::gen(
-        proto_desc.get_file(),
-        &[format!("{}.proto", proto_name).to_owned()],
-    );
-    write_output_files(output_path.to_path_buf(), proto_results);
-
-    let grpc_results: Vec<GenResult> = grpc_gen::gen(
-        proto_desc.get_file(),
-        &[format!("{}.proto", proto_name).to_owned()],
-    );
-    write_output_files(output_path.to_path_buf(), grpc_results);
-}
+extern crate protoc_rust_grpc;
 
 fn main() {
-    compile("datatypes");
-    compile("mapreduce");
-    compile("worker");
+    protoc_rust_grpc::run(protoc_rust_grpc::Args {
+        out_dir: "src",
+        includes: &["."],
+        input: &["datatypes.proto", "mapreduce.proto", "worker.proto"],
+        rust_protobuf: true, // also generate protobuf messages, not just services
+    }).expect("protoc-rust-grpc");
 }


### PR DESCRIPTION
Instead of manually trying to add all the files and compile them to
protobuf and gRPC, use one library to compile it all.