### PR TITLE
[WIP] refactor(worker): replace error-chain with failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,6 +1290,7 @@ dependencies = [
  "cerberus-proto 0.3.0",
  "clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -5,22 +5,23 @@ authors = ["Cerberus Authors <cerberus@cpssd.net>"]
 
 [dependencies]
 bson = "0.10"
+cerberus-proto = { path = "../proto" }
 clap = "~2.26"
-protobuf = "1.4.1"
 error-chain = "0.11.0"
+failure = "0.1.1"
 futures = "0.1"
 grpc = "0.2.1"
-log = "0.3.8"
 libc = "0.2.33"
 local-ip = "0.1"
+log = "0.3.8"
 procinfo = "0.4.2"
-tls-api = "0.1.10"
+protobuf = "1.4.1"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+tls-api = "0.1.10"
 util = { path = "../util" }
 uuid = { version = "0.5", features = ["v4"] }
-cerberus-proto = { path = "../proto" }
 
 [dev-dependencies]
 mocktopus = "0.1.0"

--- a/worker/src/operations/io.rs
+++ b/worker/src/operations/io.rs
@@ -2,39 +2,39 @@ use std::fs::File;
 use std::io::{BufReader, Read, Write};
 use std::path::Path;
 
-use errors::*;
+use failure::*;
 
 #[cfg(test)]
 use mocktopus;
 #[cfg(test)]
 use mocktopus::macros::*;
 
-pub fn read<P: AsRef<Path>>(path: P) -> Result<String> {
-    let file = File::open(&path)
-        .chain_err(|| format!("unable to open file {}", path.as_ref().to_string_lossy()))?;
+pub fn read<P: AsRef<Path>>(path: P) -> Result<String, Error> {
+    let file = File::open(&path).context(format!(
+        "unable to open file {}",
+        path.as_ref().to_string_lossy()
+    ))?;
 
     let mut buf_reader = BufReader::new(file);
     let mut value = String::new();
-    buf_reader.read_to_string(&mut value).chain_err(|| {
-        format!(
-            "unable to read content of {}",
-            path.as_ref().to_string_lossy()
-        )
-    })?;
+    buf_reader.read_to_string(&mut value).context(format!(
+        "unable to read content of {}",
+        path.as_ref().to_string_lossy()
+    ))?;
 
     Ok(value)
 }
 
 #[cfg_attr(test, mockable)]
-pub fn write<P: AsRef<Path>>(path: P, data: &[u8]) -> Result<()> {
-    let mut file = File::create(&path)
-        .chain_err(|| format!("unable to create file {}", path.as_ref().to_string_lossy()))?;
-    file.write_all(data).chain_err(|| {
-        format!(
-            "unable to write content to {}",
-            path.as_ref().to_string_lossy()
-        )
-    })?;
+pub fn write<P: AsRef<Path>>(path: P, data: &[u8]) -> Result<(), Error> {
+    let mut file = File::create(&path).context(format!(
+        "unable to create file {}",
+        path.as_ref().to_string_lossy()
+    ))?;
+    file.write_all(data).context(format!(
+        "unable to write content to {}",
+        path.as_ref().to_string_lossy()
+    ))?;
 
     Ok(())
 }

--- a/worker/src/operations/map.rs
+++ b/worker/src/operations/map.rs
@@ -7,10 +7,10 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use bson;
+use failure::*;
 use serde_json;
 use uuid::Uuid;
 
-use errors::*;
 use cerberus_proto::worker as pb;
 use master_interface::MasterInterface;
 use super::io;
@@ -28,7 +28,7 @@ pub struct MapInput {
 }
 
 fn log_map_operation_err(err: Error, operation_state_arc: &Arc<Mutex<OperationState>>) {
-    output_error(&err.chain_err(|| "Error running map operation."));
+    output_error(&err.context("Error running map operation."));
     operation_handler::set_failed_status(operation_state_arc);
 }
 


### PR DESCRIPTION
This is going to be an ongoing thing, as it's quite a big job. Especially regarding error handling of threads. Wrapping them in a future and putting them on an event loop or a thread pool would really help.