### PR TITLE
proto: Change type to kind in datatypes.proto

### DIFF
--- a/proto/datatypes.proto
+++ b/proto/datatypes.proto
@@ -41,7 +41,7 @@ enum TaskStatus {
   TASK_FAILED = 4;
 }
 
-enum TaskType {
+enum TaskKind {
   MAP = 0;
   REDUCE = 1;
 }
@@ -51,7 +51,7 @@ message Task {
   string job_id = 2;
   string worker_id = 3;
   TaskStatus status = 4;
-  TaskType type = 5;
+  TaskKind kind = 5;
   uint64 priority = 6;
 
   uint64 time_created = 7;


### PR DESCRIPTION
This resolves a small issue where the generated proto for `type` field creates a rust code `field_type`.