### PR TITLE
refactor(libcerberus): rewrite partitioner

### DIFF
--- a/libcerberus/examples/distributed-grep.rs
+++ b/libcerberus/examples/distributed-grep.rs
@@ -10,7 +10,6 @@ use regex::Regex;
 
 use cerberus::*;
 
-const MAP_OUTPUT_PARTITIONS: u64 = 15;
 const REGEX: &str = r"\b\w{15,}\b";
 
 struct GrepMapper;
@@ -58,14 +57,12 @@ fn run() -> Result<()> {
 
     let grep_mapper = GrepMapper;
     let grep_reducer = GrepReducer;
-    let grep_partitioner = HashPartitioner::new(MAP_OUTPUT_PARTITIONS);
 
     let matches = cerberus::parse_command_line();
 
     let registry = UserImplRegistryBuilder::new()
         .mapper(&grep_mapper)
         .reducer(&grep_reducer)
-        .partitioner(&grep_partitioner)
         .build()
         .chain_err(|| "Error building UserImplRegistry.")?;
 

--- a/libcerberus/examples/end-to-end.rs
+++ b/libcerberus/examples/end-to-end.rs
@@ -31,49 +31,15 @@ impl Reduce for TestReducer {
     }
 }
 
-struct TestPartitioner;
-impl Partition<String, String> for TestPartitioner {
-    fn partition<E>(&self, input: PartitionInputPairs<String, String>, mut emitter: E) -> Result<()>
-    where
-        E: EmitPartitionedIntermediate<String, String>,
-    {
-        for (key, value) in input.pairs {
-            let first_char = key.chars()
-                .nth(0)
-                .chain_err(|| "Cannot partition key of empty string.")?;
-            let partition = {
-                if first_char.is_lowercase() {
-                    if first_char > 'm' {
-                        1
-                    } else {
-                        0
-                    }
-                } else if first_char > 'M' {
-                    1
-                } else {
-                    0
-                }
-            };
-
-            emitter
-                .emit(partition, key, value)
-                .chain_err(|| "Error partitioning map output.")?;
-        }
-        Ok(())
-    }
-}
-
 fn run() -> Result<()> {
     let test_mapper = TestMapper;
     let test_reducer = TestReducer;
-    let test_partitioner = TestPartitioner;
 
     let matches = cerberus::parse_command_line();
 
     let registry = UserImplRegistryBuilder::new()
         .mapper(&test_mapper)
         .reducer(&test_reducer)
-        .partitioner(&test_partitioner)
         .build()
         .chain_err(|| "Error building UserImplRegistry.")?;
 

--- a/libcerberus/examples/word-counter.rs
+++ b/libcerberus/examples/word-counter.rs
@@ -5,8 +5,6 @@ extern crate error_chain;
 
 use cerberus::*;
 
-const MAP_OUTPUT_PARTITIONS: u64 = 15;
-
 struct WordCountMapper;
 impl Map for WordCountMapper {
     type Key = String;
@@ -49,14 +47,12 @@ fn run() -> Result<()> {
 
     let wc_mapper = WordCountMapper;
     let wc_reducer = WordCountReducer;
-    let wc_partitioner = HashPartitioner::new(MAP_OUTPUT_PARTITIONS);
 
     let matches = cerberus::parse_command_line();
 
     let registry = UserImplRegistryBuilder::new()
         .mapper(&wc_mapper)
         .reducer(&wc_reducer)
-        .partitioner(&wc_partitioner)
         .build()
         .chain_err(|| "Error building UserImplRegistry.")?;
 

--- a/libcerberus/src/emitter.rs
+++ b/libcerberus/src/emitter.rs
@@ -52,7 +52,7 @@ impl<'a, V: Serialize> FinalVecEmitter<'a, V> {
     ///
     /// * `sink` - A mutable reference to the `Vec` to receive the emitted values.
     pub fn new(sink: &'a mut Vec<V>) -> Self {
-        FinalVecEmitter { sink: sink }
+        FinalVecEmitter { sink }
     }
 }
 
@@ -83,7 +83,7 @@ where
     ///
     /// * `sink` - A mutable reference to the `Vec` to receive the emitted values.
     pub fn new(sink: &'a mut Vec<(K, V)>) -> Self {
-        IntermediateVecEmitter { sink: sink }
+        IntermediateVecEmitter { sink }
     }
 }
 

--- a/libcerberus/src/mapper.rs
+++ b/libcerberus/src/mapper.rs
@@ -14,10 +14,7 @@ pub struct MapInputKV {
 
 impl MapInputKV {
     pub fn new(key: String, value: String) -> Self {
-        MapInputKV {
-            key: key,
-            value: value,
-        }
+        MapInputKV { key, value }
     }
 }
 

--- a/libcerberus/src/partition.rs
+++ b/libcerberus/src/partition.rs
@@ -25,7 +25,7 @@ where
     V: Default + Serialize,
 {
     pub fn new(pairs: Vec<(K, V)>) -> Self {
-        PartitionInputPairs { pairs: pairs }
+        PartitionInputPairs { pairs }
     }
 }
 
@@ -57,9 +57,7 @@ pub struct HashPartitioner {
 
 impl HashPartitioner {
     pub fn new(partition_count: u64) -> Self {
-        HashPartitioner {
-            partition_count: partition_count,
-        }
+        HashPartitioner { partition_count }
     }
 
     fn calculate_hash<T: Hash>(&self, t: &T) -> u64 {
@@ -80,8 +78,7 @@ where
     {
         for (key, value) in input.pairs {
             let hash: u64 = self.calculate_hash(&key);
-            let partition_count: u64 = self.partition_count;
-            let partition = hash % partition_count;
+            let partition = hash % self.partition_count;
             emitter
                 .emit(partition, key, value)
                 .chain_err(|| "Error partitioning map output.")?;

--- a/libcerberus/src/reducer.rs
+++ b/libcerberus/src/reducer.rs
@@ -21,10 +21,7 @@ where
     V: Default + Serialize,
 {
     pub fn new(key: String, values: Vec<V>) -> Self {
-        ReduceInputKV {
-            key: key,
-            values: values,
-        }
+        ReduceInputKV { key, values }
     }
 }
 

--- a/libcerberus/src/serialise.rs
+++ b/libcerberus/src/serialise.rs
@@ -56,7 +56,7 @@ where
     ///
     /// * `sink` - A mutable reference to the `IntermediateOutputObject` to receive the emitted values.
     pub fn new(sink: &'a mut IntermediateOutputObject<K, V>) -> Self {
-        IntermediateOutputObjectEmitter { sink: sink }
+        IntermediateOutputObjectEmitter { sink }
     }
 }
 
@@ -70,10 +70,7 @@ where
             .partitions
             .entry(partition)
             .or_insert_with(Default::default);
-        output_array.push(IntermediateOutputPair {
-            key: key,
-            value: value,
-        });
+        output_array.push(IntermediateOutputPair { key, value });
         Ok(())
     }
 }
@@ -92,7 +89,7 @@ impl<'a, V: Default + Serialize> FinalOutputObjectEmitter<'a, V> {
     /// * `sink` - A mutable reference to the `FinalOutputObject` to receive the emitted
     /// values.
     pub fn new(sink: &'a mut FinalOutputObject<V>) -> Self {
-        FinalOutputObjectEmitter { sink: sink }
+        FinalOutputObjectEmitter { sink }
     }
 }
 
@@ -105,9 +102,9 @@ impl<'a, V: Default + Serialize> EmitFinal<V> for FinalOutputObjectEmitter<'a, V
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use serde_json;
     use std::collections::HashSet;
-    use super::*;
 
     // Test that the JSON serialisation of IntermediateOutputObject matches the libcerberus JSON
     // API.

--- a/libcerberus/tests/end-to-end.rs
+++ b/libcerberus/tests/end-to-end.rs
@@ -3,7 +3,6 @@
 #[macro_use]
 extern crate bson;
 
-use std::collections::HashSet;
 use std::env;
 use std::io::Write;
 use std::path::PathBuf;
@@ -49,17 +48,11 @@ fn run_map_valid_input() {
         panic!("Could not convert input to bson::Document.")
     }
 
-    // The ordering of partitions is not guarenteed.
-    let mut output_set = HashSet::new();
-    let expected_output1 =
-        r#"{"partitions":{"0":[{"key":"bar","value":"test"}],"1":[{"key":"zar","value":"test"}]}}"#;
-    let expected_output2 =
-        r#"{"partitions":{"1":[{"key":"zar","value":"test"}],"0":[{"key":"bar","value":"test"}]}}"#;
-    output_set.insert(expected_output1.to_owned());
-    output_set.insert(expected_output2.to_owned());
+    let expected_output =
+        r#"{"partitions":{"0":[{"key":"bar","value":"test"},{"key":"zar","value":"test"}]}}"#;
 
     let mut child = Command::new(get_bin_path())
-        .arg("map")
+        .args(&["map", "--partition_count", "1"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -79,7 +72,7 @@ fn run_map_valid_input() {
     println!("Output: {}", output_str.to_owned());
 
     assert!(output.status.success());
-    assert!(output_set.contains(&output_str.to_owned()));
+    assert_eq!(expected_output, output_str);
 }
 
 #[test]

--- a/proto/datatypes.proto
+++ b/proto/datatypes.proto
@@ -72,6 +72,10 @@ message Task {
   InputChunk input_chunk = 10;
   string output_file = 11;
   string payload_path = 12;
+
+  // Required for the map step. Should always be equal to the number of reduce
+  // steps.
+  uint64 partition_count = 13;
 }
 
 // Information about an input file. This is used to seek for specific parts of


### PR DESCRIPTION
The partition step isn't supposed to be something under the user's
control. Instead, the number of partitions should be equal to the number
of reducers. The number of reducers is now required as an argument to
the "map" subcommand of the payload binary.