### PR TITLE
feat(proto): Change task output to repeated field.

### DIFF
--- a/manager/src/splitting/reduce.rs
+++ b/manager/src/splitting/reduce.rs
@@ -4,6 +4,7 @@
 
 use chrono::Utc;
 use uuid::Uuid;
+use protobuf;
 
 use heracles_proto::datatypes::*;
 
@@ -17,7 +18,7 @@ pub fn split(job: &Job) -> Vec<Task> {
             task.set_status(TaskStatus::TASK_PENDING);
             task.set_kind(TaskKind::REDUCE);
             task.set_time_created(Utc::now().timestamp() as u64);
-            task.set_output_file(file.to_string());
+            task.set_output_files(protobuf::RepeatedField::from_vec(vec![file.to_string()]));
             task.set_payload_path(job.get_payload_path().to_string());
             task
         })

--- a/proto/datatypes.proto
+++ b/proto/datatypes.proto
@@ -70,7 +70,9 @@ message Task {
   uint64 time_done = 9;
 
   InputChunk input_chunk = 10;
-  string output_file = 11;
+  // Output files from the map and reduce tasks. In case of reduce, only one
+  // final output file is specified.
+  repeated string output_files = 11;
   string payload_path = 12;
 
   // Required for the map step. Should always be equal to the number of reduce


### PR DESCRIPTION
This allows the manager to tell the map tasks what files they should
place the individual resulting partitions in.