### PR TITLE
feat(worker-fallback): Added worker fallback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,13 +34,21 @@ jobs:
           name: Install Clippy
           command: cargo install clippy
       - run: cargo clippy
-
+  worker-fallback:
+    working_directory: /go/src/github.com/cpssd/heracles
+    docker:
+      - image: golang:1.10-alpine
+    steps:
+      - checkout
+      - run: apk -U add protobuf make git
+      - run: make worker-fallback
 workflows:
   version: 2
   test_build:
     jobs:
       - build
       - unit-test
+      - worker-fallback
   weekly-report:
     jobs:
       - analyse

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ target/
 
 # Ignore all files in proto/src which are auto-generated
 proto/src/*
+proto/datatypes/
+proto/mapreduce/
 !proto/src/lib.rs
 
 # TODO: Remove this section once legacy-proto is gone.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: build
 
-.PHONY: build release test build-docker-images clean clean-all
+.PHONY: build release test build-docker-images clean clean-all worker-fallback
 
 # Bulds the debug version of cerberus
 build:
@@ -13,6 +13,8 @@ release:
 clean:
 	cargo clean
 
+worker-fallback:
+	cd worker-fallback && make
 #############################################################
 
 # Runs all the tests

--- a/libcerberus/src/serialise.rs
+++ b/libcerberus/src/serialise.rs
@@ -32,6 +32,7 @@ where
 /// entire output of a reduce operation, ready to be serialised to JSON.
 #[derive(Debug, Default, PartialEq, Serialize)]
 pub struct FinalOutputObject<V: Default + Serialize> {
+    pub key: String,
     pub values: Vec<V>,
 }
 
@@ -154,9 +155,10 @@ mod tests {
     #[test]
     fn final_output_object_json_format() {
         let output = FinalOutputObject {
+            key: "test".to_string(),
             values: vec!["barbaz", "bazbar"],
         };
-        let expected_json_string = r#"{"values":["barbaz","bazbar"]}"#;
+        let expected_json_string = r#"{"key":"test","values":["barbaz","bazbar"]}"#;
 
         let json_string = serde_json::to_string(&output).unwrap();
 
@@ -193,6 +195,7 @@ mod tests {
     fn final_output_emitter_works() {
         let mut output = FinalOutputObject::default();
         let expected_output = FinalOutputObject {
+            key: String::new(),
             values: vec!["foo", "bar"],
         };
 

--- a/libcerberus/tests/end-to-end.rs
+++ b/libcerberus/tests/end-to-end.rs
@@ -1,7 +1,5 @@
 /// This is a set of integration tests which run against a dummy payload binary living in
 /// `libcerberus/src/bin/end-to-end.rs`.
-#[macro_use]
-extern crate bson;
 
 use std::env;
 use std::io::Write;
@@ -36,18 +34,7 @@ fn run_sanity_check() {
 
 #[test]
 fn run_map_valid_input() {
-    let bson_input = bson!({
-        "key": "foo",
-        "value":"bar zar"
-    });
-
-    let mut input_buf = Vec::new();
-    if let bson::Bson::Document(document) = bson_input {
-        bson::encode_document(&mut input_buf, &document).unwrap();
-    } else {
-        panic!("Could not convert input to bson::Document.")
-    }
-
+    let json_input = r#"{"key":"foo","value":"bar zar"}"#;
     let expected_output =
         r#"{"partitions":{"0":[{"key":"bar","value":"test"},{"key":"zar","value":"test"}]}}"#;
 
@@ -63,7 +50,7 @@ fn run_map_valid_input() {
         .stdin
         .as_mut()
         .unwrap()
-        .write_all(&input_buf[..])
+        .write_all(json_input.as_bytes())
         .unwrap();
 
     let output = child.wait_with_output().unwrap();
@@ -101,8 +88,8 @@ fn run_map_invalid_input() {
 
 #[test]
 fn run_reduce_valid_input() {
-    let json_input = r#"{"key":"foo","values":["bar","baz"]}"#;
-    let expected_output = r#"{"values":["barbaz"]}"#;
+    let json_input = r#"[{"key":"foo","values":["bar","baz"]}]"#;
+    let expected_output = r#"[{"key":"foo","values":["barbaz"]}]"#;
 
     let mut child = Command::new(get_bin_path())
         .arg("reduce")

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -1,0 +1,4 @@
+all:
+	mkdir -p datatypes mapreduce
+	protoc datatypes.proto --go_out=datatypes
+	protoc mapreduce.proto --go_out=plugins=grpc,Mdatatypes.proto=github.com/cpssd/heracles/proto/datatypes:mapreduce

--- a/worker-fallback/Makefile
+++ b/worker-fallback/Makefile
@@ -1,0 +1,37 @@
+all: deps build
+
+proto:
+	cd ../proto && make
+
+deps:
+	go get -v github.com/golang/protobuf/proto
+	go get -v github.com/golang/protobuf/protoc-gen-go
+	# The failure can be ignored as its the worker-fallback not always being
+	# available on the remote branch.
+	-go get -v -u ./worker/...
+
+build: proto
+	go build -v -o ../target/debug/worker-fallback main.go
+
+test:
+	go test -v ./worker/...
+
+release: proto deps
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -v -o ../target/release/worker-fallback main.go
+
+# TODO: This is a really bad, manual integration test. Definatelly refactor.
+bad-test: build
+	-docker kill rabbit
+	-docker rm rabbit
+	docker run -d --hostname=rabbit --name=rabbit -p 5672:5672 -p 15672:15672 rabbitmq:3-management
+	sleep 10
+	go run ./tester/tester.go
+	-mkdir -p /tmp/heracles_test_jobs/jobs/test_job/tasks
+	-mkdir -p /tmp/heracles_test_jobs/jobs/test_job/pending_map_tasks
+	-mkdir -p /tmp/heracles_test_jobs/jobs/test_job/pending_reduce_tasks
+	-mkdir -p /tmp/heracles_test_jobs/input
+	-touch /tmp/heracles_test_jobs/jobs/test_job/tasks/test_task && echo "test" > /tmp/heracles_test_jobs/jobs/test_job/tasks/test_task
+	-touch /tmp/heracles_test_jobs/jobs/test_job/pending_map_tasks/test_task && echo "test" > /tmp/heracles_test_jobs/jobs/test_job/pending_map_tasks/test_task
+	-touch /tmp/heracles_test_jobs/jobs/test_job/pending_reduce_tasks/test_task && echo "test" > /tmp/heracles_test_jobs/jobs/test_job/pending_reduce_tasks/test_task
+	-touch /tmp/heracles_test_jobs/input/wood && echo "how much wood could a wood chuck chuck if a wood chuck could chuck wood" > /tmp/heracles_test_jobs/input/wood
+	../target/debug/worker-fallback --logtostderr --broker.address=amqp://localhost:5672/ --v=2 --state.location=/tmp/heracles_test_jobs

--- a/worker-fallback/README.md
+++ b/worker-fallback/README.md
@@ -1,0 +1,35 @@
+Heracles Worker Fallback
+========================
+
+Heracles worker fallback is a full heracles compatible worker written in Go.
+It was designed as an alternative for the worker.
+
+## Dependencies:
+
+- Heracles project in `$GOPATH/src/github.com/cpssd/heracles` (symlink will do)
+- Go (1.10+ recommended, but probably works with older releases above go1.7)
+- protobuf compiler
+- Go gRPC plugin: `go get -u google.golang.org/grpc`
+
+## Building
+You can either run `make` from this directory, or `make worker-fallback` from
+the top level `Makefile`. If you want to build a statically compiled version
+run `make release`. The binaries would be placed in top level
+`target/debug/worker-fallback` and `target/release/worker-fallback`.
+
+## Running
+You can run this as any normal binary:
+
+```
+./target/debug/worker-fallback
+```
+
+At the very least you need to provide the following flags:
+- AMQP broker location: `--broker.address=amqp://valid-address:5672/`
+- Location to save state: `--state.location=/tmp/heracles-worker-fallback`
+
+## Known problems
+
+- Explicit errors would be more useful
+- Reducer has to be fully added
+- Tests need to use relative paths

--- a/worker-fallback/main.go
+++ b/worker-fallback/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cpssd/heracles/worker-fallback/worker"
+)
+
+func main() {
+	if err := worker.Main(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/worker-fallback/tester/tester.go
+++ b/worker-fallback/tester/tester.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"time"
+
+	"github.com/cpssd/heracles/proto/datatypes"
+	"github.com/cpssd/heracles/worker-fallback/worker/broker"
+	"github.com/cpssd/heracles/worker-fallback/worker/settings"
+	"github.com/golang/protobuf/proto"
+	"github.com/streadway/amqp"
+)
+
+func main() {
+	settings.Init()
+
+	c, _ := broker.NewAMQP("amqp://localhost:5672/")
+	ch := c.Channel()
+
+	var task = &datatypes.Task{
+		Id:          "test_task",
+		JobId:       "test_job",
+		PayloadPath: "../target/debug/examples/word-counter",
+		InputChunk: &datatypes.InputChunk{
+			Path: "/tmp/heracles_test_jobs/input/wood",
+		},
+		OutputFiles:    []string{"wood", "chuck"},
+		PartitionCount: 2,
+	}
+
+	seralized, _ := proto.Marshal(task)
+
+	msg := amqp.Publishing{
+		DeliveryMode: amqp.Persistent,
+		Timestamp:    time.Now(),
+		Body:         seralized,
+	}
+
+	if err := ch.Publish(
+		"",
+		settings.GetString("broker.queue_name"),
+		false,
+		false,
+		msg,
+	); err != nil {
+		panic(err)
+	}
+}

--- a/worker-fallback/worker/broker/amqp.go
+++ b/worker-fallback/worker/broker/amqp.go
@@ -1,0 +1,139 @@
+package broker
+
+import (
+	"github.com/cpssd/heracles/proto/datatypes"
+	"github.com/cpssd/heracles/worker-fallback/worker/settings"
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+	"github.com/streadway/amqp"
+
+	log "github.com/golang/glog"
+)
+
+// AMQP Errors
+var (
+	ErrUnknownTag = errors.New("unknown tag")
+	ErrAckFailure = errors.New("failed to ack message")
+)
+
+// AMQPConnection implements broker
+type AMQPConnection struct {
+	conn      *amqp.Connection
+	ch        channel
+	tags      map[string]*amqp.Delivery
+	tasks     chan *datatypes.Task
+	queueName string
+}
+
+// channel is an abstraction over amqp.Channel to allow for easier testing.
+// Only the functions needed are implemented
+type channel interface {
+	Ack(uint64, bool) error
+	Nack(uint64, bool, bool) error
+	Consume(string, string, bool, bool, bool, bool, amqp.Table) (<-chan amqp.Delivery, error)
+}
+
+// NewAMQP creates a new connection to AMQP
+func NewAMQP(addr string) (*AMQPConnection, error) {
+	log.Infof("connecting to broker at %s", addr)
+	conn, err := amqp.Dial(addr)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to open connection to AMQP")
+	}
+	// TODO: Handle closing of connection
+
+	log.Info("connected to broker")
+
+	ch, err := conn.Channel()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create a channel")
+	}
+
+	queueName := settings.GetString("broker.queue_name")
+
+	if _, err = ch.QueueDeclare(
+		queueName,
+		true,
+		false,
+		false,
+		false,
+		nil,
+	); err != nil {
+		return nil, errors.Wrap(err, "unable to declare a queue")
+	}
+
+	return &AMQPConnection{
+		conn:      conn,
+		ch:        ch,
+		tags:      make(map[string]*amqp.Delivery),
+		queueName: queueName,
+	}, nil
+}
+
+// Done implementation
+func (c *AMQPConnection) Done(task *datatypes.Task) error {
+	if d, ok := c.tags[task.GetId()]; ok {
+		if err := d.Ack(false); err != nil {
+			log.Warningf("can't ack task %s: %v", task.GetId(), err)
+			return ErrAckFailure
+		}
+		return nil
+	}
+	return ErrUnknownTag
+}
+
+// Failed implementation
+func (c *AMQPConnection) Failed(task *datatypes.Task) error {
+	if d, ok := c.tags[task.GetId()]; ok {
+		if err := d.Nack(false, true); err != nil {
+			log.Warningf("can't nack task %s: %v", task.GetId(), err)
+			return ErrAckFailure
+		}
+		return nil
+	}
+	return ErrUnknownTag
+}
+
+// Listen to messages. Should be started as a goroutine
+func (c *AMQPConnection) Listen() error {
+	c.tasks = make(chan *datatypes.Task)
+
+	msgs, err := c.ch.Consume(
+		c.queueName,
+		"",
+		false,
+		false,
+		false,
+		false,
+		nil,
+	)
+	if err != nil {
+		return errors.Wrap(err, "unable to consume")
+	}
+
+	for msg := range msgs {
+		task := &datatypes.Task{}
+		if err := proto.Unmarshal(msg.Body, task); err != nil {
+			return errors.Wrap(err, "unable to parse task")
+		}
+		log.V(2).Infof("got task %s with tag %d", task.GetId(), msg.DeliveryTag)
+		c.tags[task.GetId()] = &msg
+		c.tasks <- task
+	}
+
+	return nil
+}
+
+// Tasks returns a channel on which the messages will be received.
+func (c *AMQPConnection) Tasks() (<-chan *datatypes.Task, error) {
+	if c.tasks == nil {
+		return nil, errors.New("the broker is not listening")
+	}
+	return c.tasks, nil
+}
+
+// Channel returns the open channel of the broker. This this method
+// should not be used directly and is for debugging only.
+func (c *AMQPConnection) Channel() *amqp.Channel {
+	return c.ch.(*amqp.Channel)
+}

--- a/worker-fallback/worker/broker/amqp_test.go
+++ b/worker-fallback/worker/broker/amqp_test.go
@@ -1,0 +1,177 @@
+package broker
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cpssd/heracles/proto/datatypes"
+	"github.com/golang/protobuf/proto"
+	"github.com/streadway/amqp"
+)
+
+type MockChannel struct {
+	delivery  chan amqp.Delivery
+	acksError error
+}
+
+func (ch MockChannel) Ack(tag uint64, _ bool) error {
+	return ch.acksError
+}
+
+func (ch MockChannel) Nack(tag uint64, _, _ bool) error {
+	return ch.acksError
+}
+
+func (ch MockChannel) Consume(_, _ string, _, _, _, _ bool, _ amqp.Table) (<-chan amqp.Delivery, error) {
+	return ch.delivery, nil
+}
+
+func TestListen(t *testing.T) {
+
+	ch := &MockChannel{
+		delivery: make(chan amqp.Delivery),
+	}
+
+	c := &AMQPConnection{
+		ch:   ch,
+		tags: make(map[string]*amqp.Delivery),
+	}
+
+	waitTillStarted := make(chan bool)
+	go func() {
+		close(waitTillStarted)
+		if err := c.Listen(); err != nil {
+			t.Errorf("unexpected error when listening: %v", err)
+			return
+		}
+	}()
+	<-waitTillStarted
+
+	task := &datatypes.Task{
+		Id: "broker_test",
+	}
+
+	waitTillTaskReceived := make(chan bool)
+	go func() {
+		defer close(waitTillTaskReceived)
+		receivedTask := <-c.tasks
+		if !reflect.DeepEqual(task, receivedTask) {
+			t.Errorf("both tasks not closed")
+			return
+		}
+	}()
+
+	marshalledTask, err := proto.Marshal(task)
+	if err != nil {
+		t.Errorf("unable to marshal task: %v", err)
+		return
+	}
+
+	ch.delivery <- amqp.Delivery{
+		DeliveryTag: 1,
+		Body:        marshalledTask,
+	}
+
+	<-waitTillTaskReceived
+	close(ch.delivery)
+
+	// if tag, ok := c.tags["broker_test"]; tag != 1 || !ok {
+	// 	t.Errorf("invalid or missing tag. Wanted %d, got %d", 1, tag)
+	// }
+}
+
+func TestTasks(t *testing.T) {
+	c := &AMQPConnection{}
+	if _, err := c.Tasks(); err == nil {
+		t.Error("expected an error, have nil")
+		return
+	}
+
+	c.tasks = make(chan *datatypes.Task)
+
+	if _, err := c.Tasks(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// func TestDoneFailed(t *testing.T) {
+// 	testCases := []struct {
+// 		taskID      string
+// 		tag         uint64
+// 		ack         bool // false for nack
+// 		returnError error
+// 	}{
+// 		{
+// 			taskID:      "bad",
+// 			tag:         1,
+// 			ack:         true,
+// 			returnError: ErrUnknownTag,
+// 		}, {
+// 			taskID:      "ack_1",
+// 			tag:         2,
+// 			ack:         true,
+// 			returnError: ErrAckFailure,
+// 		}, {
+// 			taskID:      "ack_2",
+// 			tag:         3,
+// 			ack:         true,
+// 			returnError: nil,
+// 		}, {
+// 			taskID:      "bad",
+// 			tag:         4,
+// 			ack:         false,
+// 			returnError: ErrUnknownTag,
+// 		}, {
+// 			taskID:      "nack_1",
+// 			tag:         5,
+// 			ack:         false,
+// 			returnError: ErrAckFailure,
+// 		}, {
+// 			taskID:      "nack_2",
+// 			tag:         6,
+// 			ack:         false,
+// 			returnError: nil,
+// 		},
+// 	}
+
+// 	ch := &MockChannel{}
+
+// 	c := &AMQPConnection{
+// 		ch: ch,
+// 		tags: map[string]uint64{
+// 			"ack_1":  2,
+// 			"ack_2":  3,
+// 			"nack_1": 5,
+// 			"nack_2": 6,
+// 		},
+// 	}
+
+// 	for _, test := range testCases {
+// 		t.Logf("%+v", test)
+
+// 		ch.acksError = test.returnError
+// 		var err error
+// 		if test.ack {
+// 			err = c.Done(&datatypes.Task{Id: test.taskID})
+// 		} else {
+// 			err = c.Failed(&datatypes.Task{Id: test.taskID})
+// 		}
+
+// 		t.Log(err)
+// 		t.Log(test.returnError)
+// 		continue
+
+// 		if err.Error() != test.returnError.Error() {
+// 			t.Errorf("was expecting %v, got %v", test.returnError, err)
+// 			return
+// 		}
+// 	}
+
+// 	if err := c.Done(&datatypes.Task{Id: "bad_id"}); err == nil {
+// 		t.Errorf("expected an error for missing tag, got nil")
+// 	}
+
+// 	if err := c.Done(&datatypes.Task{Id: "ack_test"}); err == nil {
+// 		t.Errorf("expected an error for failing to ack")
+// 	}
+// }

--- a/worker-fallback/worker/broker/broker.go
+++ b/worker-fallback/worker/broker/broker.go
@@ -1,0 +1,26 @@
+package broker
+
+import (
+	"github.com/cpssd/heracles/proto/datatypes"
+	"github.com/cpssd/heracles/worker-fallback/worker/settings"
+)
+
+// Broker interface contains the functions needed to receive data
+type Broker interface {
+	// Listen to incoming tasks from broker
+	Listen() error
+	// Tasks returns the channel on which the tasks will be sent.
+	Tasks() (<-chan *datatypes.Task, error)
+
+	// Done marks which messages are done for and can be acknowledged
+	Done(*datatypes.Task) error
+
+	// Failed marks a message to a broker than it has failed.
+	Failed(*datatypes.Task) error
+}
+
+// New returns a new broker based on the settings
+func New() (Broker, error) {
+	addr := settings.GetString("broker.address")
+	return NewAMQP(addr)
+}

--- a/worker-fallback/worker/runner/runner.go
+++ b/worker-fallback/worker/runner/runner.go
@@ -1,0 +1,155 @@
+// Package runner runs the tasks
+// TODO: Probably rename to handler
+package runner
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/cpssd/heracles/proto/datatypes"
+	"github.com/cpssd/heracles/worker-fallback/worker/broker"
+	"github.com/cpssd/heracles/worker-fallback/worker/state"
+
+	log "github.com/golang/glog"
+)
+
+// Runner object which listens for broker connections, runs the
+// task and saves the state to state store.
+type Runner struct {
+	st state.State
+	br broker.Broker
+}
+
+// New create a new runner
+func New(st state.State, br broker.Broker) *Runner {
+	return &Runner{
+		st: st,
+		br: br,
+	}
+}
+
+// Run the individual tasks
+func (r Runner) Run() error {
+	// make sure the broker is already listening
+	taskChan, err := r.br.Tasks()
+	if err != nil {
+		return errors.Wrap(err, "unable to recieve tasks")
+	}
+
+	log.V(1).Info("listening to incoming tasks")
+
+	var wg sync.WaitGroup
+	for task := range taskChan {
+		wg.Add(1)
+		log.Infof("got new task %s", task.GetId())
+		go func(task *datatypes.Task) {
+			defer wg.Done()
+
+			if err := r.handleTask(task); err != nil {
+				r.failTask(task)
+				log.Warningf("unable to run task: %v", err)
+				return
+			}
+			if err := r.succeedTask(task); err != nil {
+				r.failTask(task)
+				log.Warningf("unable to succeed task: %v", err)
+			}
+		}(task)
+	}
+
+	log.V(1).Info("waiting for all tasks to finish")
+	wg.Wait()
+	return nil
+}
+
+// handleTask takes in a task, actually runs the payload and saves the data to
+// the state store.
+func (r Runner) handleTask(task *datatypes.Task) error {
+	task.TimeStarted = uint64(time.Now().Unix())
+	task.Status = datatypes.TaskStatus_TASK_IN_PROGRESS
+
+	if err := r.st.SaveProgress(task); err != nil {
+		return err
+	}
+
+	cmd, err := r.prepareCmd(task)
+	if err != nil {
+		return err
+	}
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Infof("output: %s", string(out))
+		return err
+	}
+	log.V(2).Infof("Output from binary: %s", out)
+
+	if err := saveResults(out, task); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// prepareCmd prepares a command to run. It gives it input in a correct
+// format and returns a exec.Cmd ready to be ran.
+func (r Runner) prepareCmd(task *datatypes.Task) (*exec.Cmd, error) {
+	// Check is libcerberus library
+
+	if err := sanityCheck(task.GetPayloadPath()); err != nil {
+		return nil, errors.Wrap(err, "payload is not a valid libheracles binary")
+	}
+
+	var in io.Reader
+	var err error
+
+	args := []string{}
+	if task.GetKind() == datatypes.TaskKind_MAP {
+		args = append(args, "map", fmt.Sprintf("--partition_count=%d", task.GetPartitionCount()))
+		in, err = mapReader(task.GetInputChunk())
+	} else {
+		args = append(args, "reduce")
+		in, err = reduceReader(task.GetInputChunk())
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command(task.GetPayloadPath(), args...)
+	cmd.Stdin = in
+
+	return cmd, nil
+}
+
+// fail tasks marks the task as failed, notifies the broker and the state
+// store.
+func (r Runner) failTask(task *datatypes.Task) error {
+	task.TimeDone = uint64(time.Now().Unix())
+	task.Status = datatypes.TaskStatus_TASK_FAILED
+
+	if err := r.st.SaveProgress(task); err != nil {
+		log.Warningf("unable to save save progress for task %s: %v", task.GetId(), err)
+	}
+	if err := r.br.Failed(task); err != nil {
+		log.Errorf("unable to tell the broker the task %s has failed: %v", task.GetId(), err)
+	}
+	return nil
+}
+
+// succeedTask marks the task as succeeded, notifies the broker and the state
+// store, and if it was unable to perform those steps, it fails the task
+// instead.
+func (r Runner) succeedTask(task *datatypes.Task) error {
+	task.TimeDone = uint64(time.Now().Unix())
+	task.Status = datatypes.TaskStatus_TASK_DONE
+
+	if err := r.st.SaveProgress(task); err != nil {
+		return err
+	}
+	return errors.Wrap(r.br.Done(task), "can't mark task as done")
+}

--- a/worker-fallback/worker/runner/runner_test.go
+++ b/worker-fallback/worker/runner/runner_test.go
@@ -1,0 +1,163 @@
+package runner
+
+import (
+	"flag"
+	"io/ioutil"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/cpssd/heracles/proto/datatypes"
+	"github.com/pkg/errors"
+)
+
+func TestMain(m *testing.M) {
+	flag.Bool("-logtostderr", true, "glog flag")
+	m.Run()
+}
+
+type stubBrokerState struct {
+	receiverError error
+	tasks         []*datatypes.Task
+	taskChan      chan *datatypes.Task
+	t             *testing.T
+	wg            sync.WaitGroup
+}
+
+// Implement broker
+func (s *stubBrokerState) Listen() error {
+	return s.receiverError
+}
+
+func (s *stubBrokerState) Tasks() (<-chan *datatypes.Task, error) {
+	return s.taskChan, s.receiverError
+}
+
+func (s *stubBrokerState) Done(task *datatypes.Task) error {
+	s.t.Logf("done %s", task.GetId())
+	s.wg.Done()
+	return nil
+}
+
+func (s *stubBrokerState) Failed(task *datatypes.Task) error {
+	s.t.Logf("failed %s", task.GetId())
+	s.wg.Done()
+	return nil
+}
+
+// Implement state store
+func (s *stubBrokerState) SaveProgress(task *datatypes.Task) error {
+	return nil
+}
+
+// TODO: !!!!! CHANGE THE TEST PATHS TO RELATIVE !!!!
+var tasks = []*datatypes.Task{
+	{
+		Id:             "maptask",
+		JobId:          "testjob",
+		PayloadPath:    "../../../target/debug/examples/word-counter",
+		OutputFiles:    []string{"/tmp/output"},
+		PartitionCount: 1,
+		Kind:           datatypes.TaskKind_MAP,
+	},
+	{
+		Id:          "reducetask",
+		JobId:       "testjob",
+		PayloadPath: "../../../target/debug/examples/word-counter",
+		OutputFiles: []string{"/tmp/wood"},
+		Kind:        datatypes.TaskKind_REDUCE,
+	},
+}
+
+func TestSanityCheck(t *testing.T) {
+	testCases := []struct {
+		payloadPath string
+		expectGood  bool
+	}{
+		{
+			// TODO: Relative paths
+			"../../../target/debug/examples/word-counter",
+			true,
+		},
+		{
+			"/bin/ls",
+			false,
+		},
+	}
+
+	for _, test := range testCases {
+		if err := sanityCheck(test.payloadPath); err != nil {
+			if test.expectGood {
+				t.Errorf("error was not expected, but got: %v", err)
+			}
+			return
+		}
+		if !test.expectGood {
+			t.Error("error was expected, but got none")
+		}
+	}
+}
+
+// TODO: This should actually test the internal errors that can happen if something goes wrong.
+func TestRun(t *testing.T) {
+	stub := &stubBrokerState{
+		tasks: tasks,
+		t:     t,
+	}
+
+	r := &Runner{
+		st: stub,
+		br: stub,
+	}
+	stub.receiverError = errors.New("test")
+
+	if err := r.Run(); err == nil {
+		t.Errorf("was expecting %v, got %s", stub.receiverError, err)
+		return
+	}
+
+	stub.receiverError = nil
+
+	stub.taskChan = make(chan *datatypes.Task, 100)
+
+	blockTillReady := make(chan struct{})
+	go func() {
+		close(blockTillReady)
+		if err := r.Run(); err != nil {
+			t.Errorf("was not expecting an error, got %v", err)
+			return
+		}
+	}()
+	<-blockTillReady
+
+	for i, task := range stub.tasks {
+		f, err := ioutil.TempFile("", "input")
+		defer os.Remove(f.Name())
+		if err != nil {
+			t.Errorf("%d: unable to create the temporary file: %v", i, err)
+			return
+		}
+		if task.GetKind() == datatypes.TaskKind_MAP {
+			f.WriteString("how much wood would a wood chuck chuck")
+		} else {
+			f.WriteString(`[{"key":"wood","value":20},{"key":"wood","value":22}]`)
+		}
+		fstat, err := f.Stat()
+		if err != nil {
+			t.Errorf("unable to stat file: %v", err)
+			return
+		}
+
+		task.InputChunk = &datatypes.InputChunk{
+			Path:      f.Name(),
+			StartByte: 0,
+			EndByte:   uint64(fstat.Size()),
+		}
+
+		stub.wg.Add(1)
+		stub.taskChan <- task
+	}
+	close(stub.taskChan)
+
+	stub.wg.Wait()
+}

--- a/worker-fallback/worker/runner/util.go
+++ b/worker-fallback/worker/runner/util.go
@@ -1,0 +1,173 @@
+// util functions used when running the payload.
+
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/cpssd/heracles/proto/datatypes"
+	log "github.com/golang/glog"
+	"github.com/pkg/errors"
+)
+
+// sanityCheck checks is a payload a valid libcerberus/libheracles
+// binary.
+func sanityCheck(payloadPath string) error {
+	out, err := exec.Command(payloadPath, "sanity-check").CombinedOutput()
+	if err != nil || string(out) != "sanity located" {
+		return errors.Wrap(err, "sanity check failed")
+	}
+	return nil
+}
+
+// mapReader takes in the input chunk and packages it up to map compabible
+// input format.
+func mapReader(in *datatypes.InputChunk) (io.Reader, error) {
+	start := in.GetStartByte()
+	end := in.GetEndByte()
+
+	f, err := os.Open(in.GetPath())
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to open input file")
+	}
+
+	// This is a human convenience change. If the end is not specified, we
+	// just go until the end of file.
+	if end == 0 {
+		if fstat, err := f.Stat(); err != nil {
+			log.Warning("unable to get end of file: %v", err)
+		} else {
+			end = uint64(fstat.Size())
+		}
+		log.V(1).Infof("end not specified: changing from 0 to %d", end)
+	}
+
+	buf := make([]byte, end-start)
+	if _, err := f.ReadAt(buf, int64(start)); err != nil && err != io.EOF {
+		return nil, errors.Wrap(err, "unable to read input data")
+	}
+
+	out, err := json.Marshal(&kv{Key: in.GetPath(), Value: string(buf)})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to parse map input")
+	}
+	log.V(2).Infof("map input: %s", out)
+
+	return bytes.NewBuffer(out), nil
+}
+
+type reducerKVs struct {
+	Key    string        `json:"key"`
+	Values []interface{} `json:"values"`
+}
+
+type reducerInput []reducerKVs
+
+func reduceReader(in *datatypes.InputChunk) (io.Reader, error) {
+	// we can assume that the whole input is for the reducer, so we just ignore
+	// the start and end bytes
+	f, err := os.Open(in.GetPath())
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to open input file")
+	}
+
+	buf, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to read input data")
+	}
+
+	kvs := []kv{}
+	if err := json.Unmarshal(buf, &kvs); err != nil {
+		return nil, errors.Wrap(err, "unable to parse JSON")
+	}
+
+	tmp := make(map[string][]interface{})
+	for _, kv := range kvs {
+		tmp[kv.Key] = append(tmp[kv.Key], kv.Value)
+	}
+
+	data := reducerInput{}
+	for key, values := range tmp {
+		data = append(data, reducerKVs{
+			Key:    key,
+			Values: values,
+		})
+	}
+
+	out, err := json.Marshal(data)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to parse reduce input")
+	}
+	log.V(2).Infof("reduce input: %s", out)
+
+	return bytes.NewReader(out), nil
+}
+
+type kv struct {
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
+}
+
+type mapOutputFormat struct {
+	Partitions map[string][]kv `json:"partitions"`
+}
+
+// saveResults takes in the bytes of the output, interprets them, and saves
+// them into required output files.
+func saveResults(in []byte, task *datatypes.Task) error {
+	switch task.GetKind() {
+	case datatypes.TaskKind_MAP:
+		return saveMapResults(in, task.GetOutputFiles())
+	case datatypes.TaskKind_REDUCE:
+		return saveReduceResults(in, task.GetOutputFiles())
+	}
+
+	return errors.New("task type not valid")
+}
+
+func saveMapResults(in []byte, output []string) error {
+	data := &mapOutputFormat{}
+	if err := json.Unmarshal(in, &data); err != nil {
+		return errors.Wrap(err, "unable to parse JSON")
+	}
+
+	for partitionName, kvPairs := range data.Partitions {
+		partition, err := strconv.Atoi(partitionName)
+		if err != nil {
+			return errors.Wrap(err, "unable to convert partition name")
+		}
+
+		filePath := output[partition]
+		log.Info(filePath)
+		pairsBytes, err := json.Marshal(kvPairs)
+		if err != nil {
+			return errors.Wrap(err, "unable to reserialize pairs")
+		}
+		if err := ioutil.WriteFile(filePath, pairsBytes, 0644); err != nil {
+			return errors.Wrap(err, "unable to write the file")
+		}
+	}
+
+	return nil
+}
+
+type reducerOutputFormat []struct {
+	Values []interface{} `json:"values"`
+}
+
+func saveReduceResults(in []byte, outputFiles []string) error {
+	// TODO: probably add some logic to divide the output keys to their
+	// 		 respectable output files.
+
+	if len(outputFiles) == 0 {
+		return errors.New("output files cannot be empty")
+	}
+
+	return ioutil.WriteFile(outputFiles[0], in, 0644)
+}

--- a/worker-fallback/worker/settings/settings.go
+++ b/worker-fallback/worker/settings/settings.go
@@ -1,0 +1,66 @@
+package settings
+
+import (
+	"flag"
+
+	log "github.com/golang/glog"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+var settings *viper.Viper
+
+// Init initializes the settings
+func Init() error {
+	settings = viper.New()
+	setDefaults()
+	settings.SetConfigName("worker")
+	settings.AddConfigPath("/etc/heracles/")
+	setOptions()
+
+	if err := settings.ReadInConfig(); err != nil {
+		log.Errorf("%v", err)
+	}
+
+	log.V(1).Info("Running with the following settings")
+	for k, v := range settings.AllSettings() {
+		log.V(1).Infof("\t%s: %+v\n", k, v)
+	}
+
+	return nil
+}
+
+func setDefaults() {
+	settings.SetDefault("broker.queue_name", "heracles_tasks")
+	settings.SetDefault("broker.address", "")
+	settings.SetDefault("state.backend", "file")
+	settings.SetDefault("state.location", "")
+}
+
+func setOptions() {
+	flag.String("broker.queue_name", "", "queue name")
+	flag.String("broker.address", "", "address of the broker")
+	flag.String("state.backend", "", "backend of the state store")
+	flag.String("state.location", "", "path to the file store")
+
+	flag.Parse()
+
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+	settings.BindPFlags(pflag.CommandLine)
+}
+
+// Get returns the value of a key.
+func Get(key string) interface{} {
+	return settings.Get(key)
+}
+
+// GetString setting
+func GetString(key string) string {
+	return settings.GetString(key)
+}
+
+// Set a value in the settings
+func Set(key string, value interface{}) {
+	settings.Set(key, value)
+}

--- a/worker-fallback/worker/state/file.go
+++ b/worker-fallback/worker/state/file.go
@@ -1,0 +1,77 @@
+package state
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/pkg/errors"
+
+	"github.com/cpssd/heracles/proto/datatypes"
+	"github.com/golang/protobuf/proto"
+
+	log "github.com/golang/glog"
+)
+
+const (
+	jobsDir          = "jobs"
+	tasksDir         = "tasks"
+	pendingMapDir    = "pending_map_tasks"
+	pendingReduceDir = "pending_reduce_tasks"
+)
+
+// FileStore implements State
+type FileStore struct {
+	path string
+}
+
+// NewFileStore creates a new file backed state
+func NewFileStore(loc string) (*FileStore, error) {
+	return &FileStore{
+		path: loc,
+	}, nil
+}
+
+// SaveProgress implementation
+func (f FileStore) SaveProgress(task *datatypes.Task) error {
+	jobDirPath := path.Join(f.path, jobsDir, task.GetJobId())
+	id := task.GetId()
+
+	taskFilePath := path.Join(jobDirPath, tasksDir, id)
+	if _, err := os.Stat(taskFilePath); os.IsNotExist(err) {
+		return errors.Wrap(err, "missing task")
+	}
+
+	var pendingFilePath string
+
+	switch task.GetKind() {
+	case datatypes.TaskKind_MAP:
+		pendingFilePath = path.Join(jobDirPath, pendingMapDir, id)
+	case datatypes.TaskKind_REDUCE:
+		pendingFilePath = path.Join(jobDirPath, pendingReduceDir, id)
+	}
+
+	if _, err := os.Stat(pendingFilePath); os.IsNotExist(err) {
+		return errors.Wrap(err, "missing pending file")
+	}
+
+	serializedTask, err := proto.Marshal(task)
+	if err != nil {
+		return errors.Wrap(err, "unable to serialize task")
+	}
+
+	if err := ioutil.WriteFile(taskFilePath, serializedTask, 0644); err != nil {
+		return errors.Wrapf(err, "unable to write task %s", task.GetId())
+	}
+
+	if task.GetStatus() == datatypes.TaskStatus_TASK_DONE {
+		log.V(1).Infof("removing task %s because its done", task.GetId())
+		if err := os.Remove(pendingFilePath); err != nil {
+			return errors.Wrapf(err, "unable to remove pending task %s", task.GetId())
+		}
+	}
+
+	log.V(1).Infof("successfully saved task %s", task.GetId())
+
+	return nil
+}

--- a/worker-fallback/worker/state/file_test.go
+++ b/worker-fallback/worker/state/file_test.go
@@ -1,0 +1,76 @@
+package state
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/cpssd/heracles/proto/datatypes"
+)
+
+func setup(testPath string, taskID string) {
+	tasksDirPath := path.Join(testPath, tasksDir)
+	os.MkdirAll(tasksDirPath, 0777)
+	ioutil.WriteFile(
+		path.Join(tasksDirPath, taskID),
+		[]byte(taskID),
+		0644,
+	)
+
+	pendingTasksDirPath := path.Join(testPath, pendingMapDir)
+	os.MkdirAll(pendingTasksDirPath, 0777)
+	ioutil.WriteFile(
+		path.Join(pendingTasksDirPath, taskID),
+		[]byte(taskID),
+		0644,
+	)
+}
+
+func cleanup(testPath string) {
+	os.RemoveAll(testPath)
+}
+
+func TestFileStore(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "heracles_worker_state_test")
+	if err != nil {
+		t.Errorf("unable to create test directory: %v", err)
+	}
+
+	st, err := NewFileStore(testDir)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	taskID := "test_task"
+	jobID := "test_job"
+
+	testJobPath := path.Join(testDir, jobsDir, jobID)
+	setup(testJobPath, taskID)
+	defer cleanup(testDir)
+
+	testTask := &datatypes.Task{
+		Id:     taskID,
+		JobId:  jobID,
+		Kind:   datatypes.TaskKind_MAP,
+		Status: datatypes.TaskStatus_TASK_IN_PROGRESS,
+	}
+	if err := st.SaveProgress(testTask); err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	pendingTasksDirPath := path.Join(testJobPath, pendingMapDir, taskID)
+
+	if _, err := os.Stat(pendingTasksDirPath); os.IsNotExist(err) {
+		t.Error("pending map file should exist and doesnt't")
+	}
+
+	testTask.Status = datatypes.TaskStatus_TASK_DONE
+	if err := st.SaveProgress(testTask); err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if _, err := os.Stat(pendingTasksDirPath); !os.IsNotExist(err) {
+		t.Error("pending map file should not exist")
+	}
+}

--- a/worker-fallback/worker/state/state.go
+++ b/worker-fallback/worker/state/state.go
@@ -1,0 +1,25 @@
+package state
+
+import (
+	"github.com/cpssd/heracles/proto/datatypes"
+	"github.com/cpssd/heracles/worker-fallback/worker/settings"
+	"github.com/pkg/errors"
+)
+
+// State contains the availabel functions for worker
+type State interface {
+	// Save a task in the state
+	SaveProgress(*datatypes.Task) error
+}
+
+// New returns a new state store
+func New() (State, error) {
+	kind := settings.Get("state.backend").(string)
+	switch kind {
+	case "file":
+		location := settings.Get("state.location").(string)
+		return NewFileStore(location)
+	}
+
+	return nil, errors.New("unknown state kind")
+}

--- a/worker-fallback/worker/worker.go
+++ b/worker-fallback/worker/worker.go
@@ -1,0 +1,51 @@
+package worker
+
+import (
+	"github.com/golang/glog"
+	log "github.com/golang/glog"
+	"github.com/pkg/errors"
+
+	"github.com/cpssd/heracles/worker-fallback/worker/broker"
+	"github.com/cpssd/heracles/worker-fallback/worker/runner"
+	"github.com/cpssd/heracles/worker-fallback/worker/settings"
+	"github.com/cpssd/heracles/worker-fallback/worker/state"
+)
+
+// Main entrypoint for the worker fallback.
+func Main() error {
+	if err := settings.Init(); err != nil {
+		return errors.Wrap(err, "unable to initialize settings")
+	}
+
+	glog.Info("starting heracles worker fallback")
+
+	st, err := state.New()
+	if err != nil {
+		return errors.Wrap(err, "unable to connect to state")
+	}
+	br, err := broker.New()
+	if err != nil {
+		return errors.Wrap(err, "unable to create a broker connection")
+	}
+
+	// TODO: We  probably might want to recover instead.
+	waitUntilListening := make(chan bool)
+	defer close(waitUntilListening)
+	go func() {
+		waitUntilListening <- true
+		if err := br.Listen(); err != nil {
+			log.Fatalf("unable to listen to broker: %v", err)
+		}
+		return
+	}()
+	<-waitUntilListening
+
+	log.Info("starting runner")
+
+	// Run starts listening and holds.
+	if err := runner.New(st, br).Run(); err != nil {
+		return errors.Wrap(err, "error running a command")
+	}
+
+	return nil
+}

--- a/worker/src/state/file.rs
+++ b/worker/src/state/file.rs
@@ -104,7 +104,7 @@ mod tests {
 
     #[test]
     fn test_file_store() {
-        let test_dir = temp_dir().join("heracles_test").join("state");
+        let test_dir = temp_dir().join("heracles_test_jobs").join("state");
 
         let st = FileStore::new(&test_dir).unwrap();
 
@@ -113,7 +113,7 @@ mod tests {
 
         let test_job_path = st.job_dir_path(job_id.clone());
         assert_eq!(
-            "/tmp/heracles_test/state/jobs/test_job",
+            "/tmp/heracles_test_jobs/state/jobs/test_job",
             test_job_path.to_str().unwrap()
         );
         setup(&test_job_path, task_id.clone());


### PR DESCRIPTION
Contains the basic code for a working fallback heracles worker written in Golang.

All of the necessary documentation is in README.

This change also moves the input to map from BSON back to JSON (it didn't want to work too well). I don't think it would have that much of an impact anyways.

I realise this is a huge deviation from the current code base. But this code is designed to be used in case the worker doesn't work out. I have been working on #387  for a long time, and trying to integrate it in was a real pain.

I wrote this worker as I am more comfortable with the language, and a rewrite was probably a good idea considering the  state of things and how difficult it was integrating, which I am still trying to do. I kept it as a side project as I knew it was not discussed. But it literally took me 2.5 days to do. 

There are still some problems, especially with the reducer, and the tests need work, but its working - properly listening for tasks from the broker and executing them locally. I am a bit unsure about specifying the output files but I will work on that.