### PR TITLE
feat(cli): CLIv2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,7 @@ release:
 
 clean:
 	cargo clean
-
-worker-fallback:
-	cd worker-fallback && make
+	
 #############################################################
 
 # Runs all the tests
@@ -46,3 +44,22 @@ clean-docker-images:
 clean-docker: docker-compose-down clean-docker-images
 
 clean-all: clean-docker clean
+
+#############################################################
+
+go-build: cli2 worker-fallback
+
+go-deps:
+	go get -v github.com/golang/protobuf/proto
+	go get -v github.com/golang/protobuf/protoc-gen-go
+	-go get -v -u ./worker-fallback/...
+	-go get -v -u ./cmd/hrctl/...
+
+go-proto: go-deps
+	cd proto && make
+
+worker-fallback: go-proto
+	cd worker-fallback && make
+
+cli2: go-proto
+	cd cmd && make hrctl

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Fork of [cerberus](https://github.com/cpssd/cerberus)
 - Rust Nightly
 - Protobuf Compiler
 - net-tools (if running worker locally)
+- Go (1.10+ recommended)
 
 #### Deployment
 - Docker
@@ -29,7 +30,8 @@ Fork of [cerberus](https://github.com/cpssd/cerberus)
 Build everything by running:
 
 ```
-$ cargo build --all
+$ make build
+$ make go-build
 ```
 
 ---

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,0 +1,4 @@
+all: hrctl
+
+hrctl:
+	go build -v -o ../target/debug/hrctl hrctl/hrctl.go

--- a/cmd/hrctl/app/app.go
+++ b/cmd/hrctl/app/app.go
@@ -1,0 +1,54 @@
+package app
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+
+	dpb "github.com/cpssd/heracles/proto/datatypes"
+)
+
+// Errors
+var (
+	errEmptyJobPath   = "job path is empty"
+	errUnmarshaling   = "unable to unmarshal job from file"
+	errEmptyInputDir  = "input directory cannot be empty"
+	errEmptyPayload   = "payload path cannot be empty"
+	errInvalidSepator = "cannot use undefined input separator"
+)
+
+// Run the application
+func Run() error {
+	return parse().Run(os.Args)
+}
+
+func loadJob(jobPath string) (*dpb.Job, error) {
+	if jobPath == "" {
+		return nil, errors.New(errEmptyJobPath)
+	}
+
+	data, err := ioutil.ReadFile(path.Clean(jobPath))
+	if err != nil {
+		return nil, err
+	}
+
+	job := &dpb.Job{}
+	if err := proto.UnmarshalText(string(data), job); err != nil {
+		return nil, errors.Wrap(err, errUnmarshaling)
+	}
+
+	// Check required arguments
+	if job.GetInputDirectory() == "" {
+		return nil, errors.New(errEmptyInputDir)
+	}
+	if job.GetPayloadPath() == "" {
+		return nil, errors.New(errEmptyPayload)
+	}
+	if job.GetInputKind() == dpb.InputDataKind_UNDEFINED {
+		return nil, errors.New(errInvalidSepator)
+	}
+	return job, nil
+}

--- a/cmd/hrctl/app/parser.go
+++ b/cmd/hrctl/app/parser.go
@@ -1,0 +1,160 @@
+package app
+
+import (
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+func parse() *cli.App {
+	app := cli.NewApp()
+	app.Name = "hrctl"
+	app.Authors = []cli.Author{
+		{Name: "Heracles Authors", Email: "heracles@cpssd.net"},
+	}
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:   "manager, m",
+			Value:  "[::]:8081",
+			Usage:  "Address to the manager",
+			EnvVar: "HERACLES_MANAGER",
+		},
+	}
+	app.Commands = []cli.Command{
+		{
+			Name:   "schedule",
+			Usage:  "schedule a job from given input file",
+			Action: schedule,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "job_file, f",
+					Usage: "load the job configuration from `FILE`",
+					Value: "",
+				},
+			},
+			ArgsUsage: " ",
+		}, {
+			Name:      "cancel",
+			Usage:     "cancel a job",
+			Action:    cancel,
+			ArgsUsage: "<job-id>",
+		}, {
+			Name:  "describe",
+			Usage: "describe a resource in heracles",
+			Subcommands: []cli.Command{
+				{
+					Name:      "cluster",
+					Usage:     "Information about the heracles cluster",
+					ArgsUsage: " ",
+					Action:    describeCluster,
+				}, {
+					Name:      "queue",
+					Usage:     "Current jobs in the queue",
+					ArgsUsage: " ",
+					Action:    describeQueue,
+				}, {
+					Name:      "job",
+					Usage:     "Specific Job information",
+					ArgsUsage: "<JOB-ID>",
+					Action: func(c *cli.Context) error {
+						if c.Args().First() == "" {
+							return errors.New("Job ID must be specified")
+						}
+						return describeJobs(c)
+					},
+				}, {
+					Name:      "jobs",
+					Usage:     "List of jobs which are currently in progress",
+					ArgsUsage: " ",
+					Action:    describeJobs,
+				}, {
+					Name:      "task",
+					Usage:     "Specific job nformation",
+					ArgsUsage: "<TASK-ID>",
+					Action: func(c *cli.Context) error {
+						if c.Args().First() == "" {
+							return errors.New("Task ID must be specified")
+						}
+						return describeTasks(c)
+					},
+				}, {
+					Name:      "tasks",
+					Usage:     "Lists of all tasks",
+					ArgsUsage: " ",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "job",
+							Usage: "limit tasks to specific job",
+							Value: "",
+						},
+					},
+					Action: describeTasks,
+				},
+			},
+		},
+	}
+	return app
+}
+
+func schedule(c *cli.Context) error {
+	job, err := loadJob(c.String("job_file"))
+	if err != nil {
+		return errors.Wrap(err, "unable to get job from file")
+	}
+
+	conn, err := connect(c.String("manager"))
+	if err != nil {
+		return errors.Wrap(err, "unable to connect to manager")
+	}
+
+	return conn.schedule(job)
+}
+
+func cancel(c *cli.Context) error {
+	conn, err := connect(c.String("manager"))
+	if err != nil {
+		return errors.Wrap(err, "unable to connect to manager")
+	}
+
+	jobID := c.Args().First()
+	if jobID == "" {
+		return errors.New("job ID cannot be empty")
+	}
+
+	return conn.cancel(jobID)
+}
+
+func describeCluster(c *cli.Context) error {
+	conn, err := connect(c.String("manager"))
+	if err != nil {
+		return errors.Wrap(err, "unable to connect to manager")
+	}
+
+	return conn.describeCluster()
+}
+
+func describeQueue(c *cli.Context) error {
+	conn, err := connect(c.String("manager"))
+	if err != nil {
+		return errors.Wrap(err, "unable to connect to manager")
+	}
+
+	return conn.describeQueue()
+}
+
+func describeJobs(c *cli.Context) error {
+	conn, err := connect(c.String("manager"))
+	if err != nil {
+		return errors.Wrap(err, "unable to connect to manager")
+	}
+
+	return conn.describeJobs(c.Args().First())
+}
+
+func describeTasks(c *cli.Context) error {
+	conn, err := connect(c.String("manager"))
+	if err != nil {
+		return errors.Wrap(err, "unable to connect to manager")
+	}
+
+	return conn.describeTasks(c.Args().First(), c.String("job"))
+}

--- a/cmd/hrctl/app/runner.go
+++ b/cmd/hrctl/app/runner.go
@@ -1,0 +1,167 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+
+	dpb "github.com/cpssd/heracles/proto/datatypes"
+	pb "github.com/cpssd/heracles/proto/mapreduce"
+)
+
+type conn struct {
+	*grpc.ClientConn
+	pb.JobScheduleServiceClient
+}
+
+func connect(addr string) (*conn, error) {
+	c := &conn{}
+	var err error
+	c.ClientConn, err = grpc.Dial(addr, grpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+	c.JobScheduleServiceClient = pb.NewJobScheduleServiceClient(c.ClientConn)
+	return c, nil
+}
+
+func (c *conn) schedule(job *dpb.Job) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	res, err := c.Schedule(ctx, &pb.ScheduleRequest{Job: job})
+	if err != nil {
+		return errors.Wrap(err, "unable to schedule job")
+	}
+
+	fmt.Println("Successfully scheduled. You can see the job status by running:")
+	fmt.Println("\thrctl describe job", res.GetJobId())
+	return nil
+}
+
+func (c *conn) cancel(jobID string) error {
+	ctx, cancelCtx := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancelCtx()
+
+	if _, err := c.Cancel(ctx, &pb.CancelRequest{JobId: jobID}); err != nil {
+		return errors.Wrap(err, "unable to cancel job")
+	}
+
+	fmt.Printf("Job %s successfully cancelled\n", jobID)
+
+	return nil
+}
+
+func (c *conn) describe(req *pb.DescribeRequest) (*pb.Description, error) {
+	ctx, cancelCtx := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelCtx()
+	return c.Describe(ctx, req)
+}
+
+func (c *conn) describeCluster() error {
+	req := &pb.DescribeRequest{
+		Resource: pb.ResourceType_CLUSTER,
+	}
+
+	res, err := c.describe(req)
+	if err != nil {
+		return errors.Wrap(err, "unable to get cluster information")
+	}
+	return proto.MarshalText(os.Stdout, res.GetCluster())
+}
+
+func (c *conn) describeQueue() error {
+	req := &pb.DescribeRequest{
+		Resource: pb.ResourceType_QUEUE,
+	}
+
+	res, err := c.describe(req)
+	if err != nil {
+		return errors.Wrap(err, "unable to get queue")
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	for _, job := range res.GetJobs() {
+		age := time.Now().Sub(time.Unix(int64(job.GetTimeScheduled()), 0))
+		table.Append([]string{job.GetId(), fmt.Sprint(age, "ago")})
+	}
+	table.Render()
+	return nil
+}
+
+func (c *conn) describeJobs(jobID string) error {
+	req := &pb.DescribeRequest{
+		Resource: pb.ResourceType_JOB,
+		JobId:    jobID,
+	}
+
+	res, err := c.describe(req)
+	if err != nil {
+		return errors.Wrap(err, "unable to get job information")
+	}
+
+	jobs := res.GetJobs()
+	switch len(jobs) {
+	case 0:
+		fmt.Println("No jobs to display")
+	case 1:
+		if err := proto.MarshalText(os.Stdout, jobs[0]); err != nil {
+			return errors.Wrap(err, "unable to display job information")
+		}
+	default:
+		table := tablewriter.NewWriter(os.Stdout)
+		for _, job := range jobs {
+			age := time.Now().Sub(time.Unix(int64(job.GetTimeScheduled()), 0))
+			table.Append([]string{
+				job.GetId(),
+				job.GetStatus().String(),
+				fmt.Sprint(age, "ago"),
+			})
+		}
+		table.Render()
+	}
+
+	return nil
+}
+
+func (c *conn) describeTasks(taskID, jobID string) error {
+	req := &pb.DescribeRequest{
+		Resource: pb.ResourceType_TASK,
+		TaskId:   taskID,
+		JobId:    jobID,
+	}
+
+	res, err := c.describe(req)
+	if err != nil {
+		return errors.Wrap(err, "unable to display task information")
+	}
+
+	tasks := res.GetTasks()
+	switch len(tasks) {
+	case 0:
+		fmt.Println("No tasks to display")
+	case 1:
+		if err := proto.MarshalText(os.Stdout, tasks[0]); err != nil {
+			return errors.Wrap(err, "unable to display job information")
+		}
+	default:
+		table := tablewriter.NewWriter(os.Stdout)
+		for _, task := range tasks {
+			age := time.Now().Sub(time.Unix(int64(task.GetTimeCreated()), 0))
+			table.Append([]string{
+				task.GetId(),
+				task.GetStatus().String(),
+				fmt.Sprint(age, "ago"),
+			})
+		}
+		table.Render()
+	}
+
+	return nil
+}

--- a/cmd/hrctl/hrctl.go
+++ b/cmd/hrctl/hrctl.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cpssd/heracles/cmd/hrctl/app"
+)
+
+func main() {
+	if err := app.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/examples/example_job.pb
+++ b/examples/example_job.pb
@@ -1,0 +1,4 @@
+input_directory: "/shared/word-counter"
+payload_path: "/shared/payload_path"
+input_kind: DATA_TEXT_NEWLINES
+priority: 200

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,10 +1,13 @@
 extern crate protoc_rust_grpc;
 
+use std::process::Command;
+use std::fs;
+
 fn main() {
     protoc_rust_grpc::run(protoc_rust_grpc::Args {
         out_dir: "src",
         includes: &["."],
         input: &["datatypes.proto", "mapreduce.proto"],
         rust_protobuf: true, // also generate protobuf messages, not just services
-    }).expect("protoc-rust-grpc");
+    }).expect("protoc-rust-grpc")
 }

--- a/worker-fallback/Makefile
+++ b/worker-fallback/Makefile
@@ -1,4 +1,4 @@
-all: deps build
+all: build
 
 proto:
 	cd ../proto && make
@@ -10,7 +10,7 @@ deps:
 	# available on the remote branch.
 	-go get -v -u ./worker/...
 
-build: proto
+build:
 	go build -v -o ../target/debug/worker-fallback main.go
 
 test:


### PR DESCRIPTION
This Heracles-compatible CLIv2 was added ages ago. When #407 is merged, it would use its method of generating protos. The two PRs are independent but would probably share a bit of code - mostly `Makefile` targets.

Perhaps the worker-fallback would be moved into `cmd` as well per Go project layout guides.